### PR TITLE
bumped nth-check from 1.0.2 to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9446,7 +9446,7 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "nth-check": "^2.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -14044,8 +14044,8 @@
       }
     },
     "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"


### PR DESCRIPTION
*Description of changes:*
Updated nth-check dependency to mitigate the security vulnerability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
